### PR TITLE
allow to use GOOGLE_APPLICATION_CREDENTIALS_DATA with json data

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ You can also specify a verification token `GOOGLE_VERIFICATION_TOKEN` and `PORT`
 
 `PORT=YOUR_APP_PORT GOOGLE_APPLICATION_CREDENTIALS=YOUR_GOOGLE_CREDENTIALS_FILE GOOGLE_VERIFICATION_TOKEN=YOUR_GOOGLE_VERIFICATION_TOKEN node bot.js`
 
+#### Google Credentials on Heroku like environement
+
+If you are running on Heroku you can't rely on a json file. You must have the json
+available as a environment variable direclty. It is described [here](https://github.com/googleapis/google-auth-library-nodejs/blob/master/README.md#loading-credentials-from-environment-variables).
+
+So instead of setting a `GOOGLE_APPLICATION_CREDENTIALS` environment variable you can
+provide the json data inside `GOOGLE_APPLICATION_CREDENTIALS_DATA` like that:
+
+```
+GOOGLE_APPLICATION_CREDENTIALS_DATA='{
+  "type": "service_account",
+  "project_id": "your-project-id",
+  "private_key_id": "your-private-key-id",
+  "private_key": "your-private-key",
+  "client_email": "your-client-email",
+  "client_id": "your-client-id",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "your-cert-url"
+}' node bot.js
+```
+
 ### Configure Webhook URL
 
 By default, your bot will receive messages from Google at `https://<my_url>/hangouts/receive`. You will need to configure your Google Hangouts Bot profile with this URL.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can also specify a verification token `GOOGLE_VERIFICATION_TOKEN` and `PORT`
 
 `PORT=YOUR_APP_PORT GOOGLE_APPLICATION_CREDENTIALS=YOUR_GOOGLE_CREDENTIALS_FILE GOOGLE_VERIFICATION_TOKEN=YOUR_GOOGLE_VERIFICATION_TOKEN node bot.js`
 
-#### Google Credentials on Heroku like environement
+#### Loading credentials from environment variables
 
 If you are running on Heroku you can't rely on a json file. You must have the json
 available as a environment variable direclty. It is described [here](https://github.com/googleapis/google-auth-library-nodejs/blob/master/README.md#loading-credentials-from-environment-variables).

--- a/bot.js
+++ b/bot.js
@@ -24,8 +24,8 @@ const env = require('node-env-file');
 
 env(__dirname + '/.env');
 
-if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-    console.log('Error: Specify a GOOGLE_APPLICATION_CREDENTIALS in environment.');
+if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && !process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA) {
+    console.log('Error: Specify a GOOGLE_APPLICATION_CREDENTIALS or GOOGLE_APPLICATION_CREDENTIALS_DATA in environment.');
     process.exit(1);
 }
 

--- a/bot.js
+++ b/bot.js
@@ -27,7 +27,7 @@ env(__dirname + '/.env');
 let google_auth_params = {}
 if(process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA) {
   // Handle json file as a environement variable for Heroku like systems
-  let google_auth_params = {
+  google_auth_params = {
       credentials: JSON.parse(process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA)
   }
 }

--- a/bot.js
+++ b/bot.js
@@ -24,7 +24,14 @@ const env = require('node-env-file');
 
 env(__dirname + '/.env');
 
-if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && !process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA) {
+let google_auth_params = {}
+if(process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA) {
+  // Handle json file as a environement variable for Heroku like systems
+  let google_auth_params = {
+      credentials: JSON.parse(process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA)
+  }
+}
+else if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && !process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA) {
     console.log('Error: Specify a GOOGLE_APPLICATION_CREDENTIALS or GOOGLE_APPLICATION_CREDENTIALS_DATA in environment.');
     process.exit(1);
 }
@@ -41,6 +48,7 @@ const controller = Botkit.googlehangoutsbot({
     token,
     port,
     debug,
+    google_auth_params: google_auth_params
 });
 
 const bot = controller.spawn({});


### PR DESCRIPTION
This pull request follow the pull request howdyai/botkit#1543 that is allowing to use `GOOGLE_APPLICATION_CREDENTIALS_DATA` inside botkit to populate google credentials via json env variable instead of a file. 